### PR TITLE
Fix hostname to work on MacOS

### DIFF
--- a/src/GenericContainer.php
+++ b/src/GenericContainer.php
@@ -72,7 +72,18 @@ class GenericContainer implements Container
 
     public function getHost(): string
     {
+        // @todo implement env vars like DOCKER_HOST
+
+        if (!$this->insideContainer()) {
+           return 'localhost';
+        }
+
         return $this->inspect()->gateway;
+    }
+
+    private function insideContainer(): bool
+    {
+        return file_exists("/.dockerenv");
     }
 
     public function getMappedPort(string $port): int

--- a/src/Module/MySql/MySqlContainer.php
+++ b/src/Module/MySql/MySqlContainer.php
@@ -27,6 +27,15 @@ final class MySqlContainer extends GenericContainer
             ]);
     }
 
+    public function getHost() : string
+    {
+        $host = parent::getHost();
+
+        // depending on compile flags, mysql tries to connect on a local socket when
+        // given 'localhost' as host so we need to correct it
+        return $host == 'localhost' ? '127.0.0.1' : $host;
+    }
+
     public function getDsn(): string
     {
         return "mysql:host={$this->getHost()};port={$this->getFirstMappedPort()};dbname={$this->database}";


### PR DESCRIPTION
A quick fix to mostly return 'localhost' as the host name of a container

See discussion at #1 