### PR TITLE
Check if "pdo_mysql" is loaded before test

### DIFF
--- a/tests/Module/MySqlContainerTest.php
+++ b/tests/Module/MySqlContainerTest.php
@@ -16,6 +16,12 @@ final class MySqlContainerTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (extension_loaded('pdo_mysql') === false) {
+            self::markTestSkipped('The pdo_mysql extension is not installed/enabled.');
+
+            return;
+        }
+
         self::$container = new MySqlContainer();
         self::$container->start();
     }


### PR DESCRIPTION
This PR adds a check for `extension_loaded` prior to running `MySqlContainer` test, avoiding test failure when the extension is not available (installed / enabled).